### PR TITLE
Change metabox title from plural label to singular

### DIFF
--- a/inc/class.WordPress_Radio_Taxonomy.php
+++ b/inc/class.WordPress_Radio_Taxonomy.php
@@ -91,7 +91,7 @@ class WordPress_Radio_Taxonomy {
 	 */
 	public function add_meta_box() {
 		if( ! is_wp_error( $this->tax_obj ) && isset($this->tax_obj->object_type ) ) foreach ( $this->tax_obj->object_type as $post_type ):
-			$label = $this->tax_obj->labels->name;
+			$label = $this->tax_obj->labels->singular_name;
 			$id = ! is_taxonomy_hierarchical( $this->taxonomy ) ? 'radio-tagsdiv-' . $this->taxonomy : 'radio-' . $this->taxonomy . 'div' ;
 			add_meta_box( $id, $label ,array( $this,'metabox' ), $post_type , 'side', 'core', array( 'taxonomy'=>$this->taxonomy ) );
 		endforeach;


### PR DESCRIPTION
Given that someone can only select one option from the taxonomy, as opposed to multiple, using the plural label for the metabox title is potentially confusing. Better to use the singular label, to reinforce the idea that only one can be chosen.

I think this is the only place it’s relevant, but let me know if it makes sense to change it elsewhere, too!