### PR TITLE
Fix breaking quick-edit on Taxonomy screens. Closes #63.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,6 +50,8 @@ module.exports = function(grunt) {
 					'!composer.json',
 					'!package-lock.json',
 					'!build/**',
+					'!license.txt',
+					'!js\dist\index.deps.json',
 					'!readme.md',
 					'!wp-assets/**',
 					'!.git/**',
@@ -156,25 +158,21 @@ module.exports = function(grunt) {
 				],
 				overwrite: true,
 				replacements: [
-					{ 
-						from: /\*\*Stable tag:\*\* .*/,
-						to: "**Stable tag:** <%= pkg.version %>  "
-					},
 					{
-						from: /Stable tag: .*/,
+						from: /Stable tag:.*$/m,
 						to: "Stable tag: <%= pkg.version %>"
 					},
-					{ 
-						from: /Version:.\d+(\.\d+)+/,
-						to: "Version: <%= pkg.version %>"
+					{
+						from: /Version:.*$/m,
+						to: "Version:           <%= pkg.version %>"
 					},
 					{
-						from: /static \$version = \'.*.'/m,
-						to: "static $version = '<%= pkg.version %>'"
+						from: /public static \$version = \'.*.'/m,
+						to: "public static $version = '<%= pkg.version %>'"
 					},
 					{
-						from: /CONST VERSION = \'.*/,
-						to: "CONST VERSION = '<%= pkg.version %>';"
+						from: /public \$version      = \'.*.'/m,
+						to: "public $version      = '<%= pkg.version %>'"
 					}
 				]
 			}

--- a/inc/class.WordPress_Radio_Taxonomy.php
+++ b/inc/class.WordPress_Radio_Taxonomy.php
@@ -118,8 +118,6 @@ class WordPress_Radio_Taxonomy {
 	 */
 	public function metabox( $post, $box ) {
 
-		wp_enqueue_script( 'radiotax' );
-
 		$defaults = array( 'taxonomy' => 'category' );
 		if ( ! isset( $box['args'] ) || ! is_array( $box['args'] ) ) {
 			$args = array();
@@ -479,12 +477,9 @@ class WordPress_Radio_Taxonomy {
 	/**
 	 * Add nonces to quick edit and bulk edit
 	 *
-	 * @return HTML
 	 * @since 1.7.0
 	 */
 	public function quick_edit_nonce() {
-		
-		wp_enqueue_script( 'radiotax' );
 
 		if ( $this->printNonce ) {
 			$this->printNonce = FALSE;

--- a/languages/radio-buttons-for-taxonomies.pot
+++ b/languages/radio-buttons-for-taxonomies.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the Radio Buttons for Taxonomies package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Radio Buttons for Taxonomies 2.0.0\n"
+"Project-Id-Version: Radio Buttons for Taxonomies 2.0.3\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/Radio-Buttons-for-Taxonomies\n"
-"POT-Creation-Date: 2019-07-01 08:38:50+00:00\n"
+"POT-Creation-Date: 2019-10-16 17:16:35+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: grunt-wp-i18n 1.0.3\n"
 
-#: inc/class.WordPress_Radio_Taxonomy.php:190
+#: inc/class.WordPress_Radio_Taxonomy.php:188
 #. translators: %s: add new taxonomy label
 msgid "+ %s"
 msgstr ""
@@ -39,23 +39,23 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
-#: radio-buttons-for-taxonomies.php:84
+#: radio-buttons-for-taxonomies.php:83
 msgid "Cloning this object is forbidden."
 msgstr ""
 
-#: radio-buttons-for-taxonomies.php:93
+#: radio-buttons-for-taxonomies.php:92
 msgid "Unserializing instances of this class is forbidden."
 msgstr ""
 
-#: radio-buttons-for-taxonomies.php:203
+#: radio-buttons-for-taxonomies.php:204
 msgid "Radio Buttons for Taxonomies Options Page"
 msgstr ""
 
-#: radio-buttons-for-taxonomies.php:277
+#: radio-buttons-for-taxonomies.php:300
 msgid "Settings"
 msgstr ""
 
-#: radio-buttons-for-taxonomies.php:293
+#: radio-buttons-for-taxonomies.php:317
 msgid "Donate"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   },
   "entry point": "build/index.js",
   "devDependencies": {
-    "@wordpress/scripts": "3.3.0",
-    "eslint": "^6.0.1",
-    "eslint-plugin-react": "^7.14.2",
+    "@wordpress/scripts": "5.1.0",
+    "eslint": "^6.5.1",
+    "eslint-plugin-react": "^7.16.0",
     "grunt": "^1.0.4",
     "grunt-checkbranch": "~1.0.4",
     "grunt-contrib-clean": "~2.0.0",
@@ -36,6 +36,6 @@
     "grunt-wp-i18n": "^1.0.3",
     "grunt-wp-readme-to-markdown": "~2.0.1",
     "jshint-stylish": "~2.2.1",
-    "load-grunt-tasks": "~5.0.0"
+    "load-grunt-tasks": "~5.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "radio-buttons-for-taxonomies",
   "author": "helgatheviking",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Use radio buttons for any taxonomy so users can only select 1 term at a time",
   "repository": {
     "type": "git",

--- a/radio-buttons-for-taxonomies.php
+++ b/radio-buttons-for-taxonomies.php
@@ -3,7 +3,7 @@
  * Plugin Name: 	  Radio Buttons for Taxonomies
  * Plugin URI: 		  http://www.kathyisawesome.com/441/radio-buttons-for-taxonomies
  * Description: 	  Use radio buttons for any taxonomy so users can only select 1 term at a time
- * Version:           2.0.0
+ * Version:           2.0.3
  * Author:            helgatheviking
  * Author URI:        https://www.kathyisawesome.com
  * Requires at least: 4.5.0
@@ -49,7 +49,7 @@ class Radio_Buttons_For_Taxonomies {
 	protected static $_instance = null;
 
 	/* @var str $version */
-	public static $version = '2.0.2';
+	public static $version = '2.0.3';
 
 	/* @var array $options - The plugin's options.
 	public $options = array();

--- a/radio-buttons-for-taxonomies.php
+++ b/radio-buttons-for-taxonomies.php
@@ -427,10 +427,9 @@ endif;
  * @since  1.6
  * @return Radio_Buttons_for_Taxonomies
  */
-function Radio_Buttons_for_Taxonomies() {
+function radio_buttons_for_taxonomies() {
 	return Radio_Buttons_for_Taxonomies::instance();
 }
 
 // Global for backwards compatibility.
-$GLOBALS['Radio_Buttons_for_Taxonomies'] = Radio_Buttons_for_Taxonomies();
-
+$GLOBALS['Radio_Buttons_for_Taxonomies'] = radio_buttons_for_taxonomies();

--- a/radio-buttons-for-taxonomies.php
+++ b/radio-buttons-for-taxonomies.php
@@ -249,6 +249,23 @@ class Radio_Buttons_for_Taxonomies {
 	public function admin_script( $hook ){
 		$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 		wp_register_script( 'radiotax', plugins_url( 'js/radiotax' . $suffix . '.js', __FILE__ ), array( 'jquery', 'inline-edit-post' ), self::$version, true );
+
+		// Get admin screen id.
+		$screen      = get_current_screen();
+		$screen_base = $screen ? $screen->base : '';
+		$post_type    = $screen ? $screen->post_type : '';
+
+		/*
+		 * Enqueue scripts.
+		 */
+		if ( 'post' === $screen_base || 'edit' === $screen_base ) {
+
+			// If the post type has a radio taxonomy.
+			if( $post_type && array_intersect( $this->options['taxonomies'], get_object_taxonomies( $post_type, 'names' ) ) ) {
+				wp_enqueue_script( 'radiotax' );
+			}
+
+		}
 	}
 
 	/**

--- a/radio-buttons-for-taxonomies.php
+++ b/radio-buttons-for-taxonomies.php
@@ -103,14 +103,12 @@ class Radio_Buttons_for_Taxonomies {
 
 			// Include required files
 			include_once( 'inc/class.WordPress_Radio_Taxonomy.php' );
-			
+
 			if( $this->is_wp_version_gte('4.4.0') ){
 				include_once( 'inc/class.Walker_Category_Radio.php' );
 			} else {
 				include_once( 'inc/class.Walker_Category_Radio_old.php' );
 			}
-
-			$this->options = get_option( 'radio_button_for_taxonomies_options', true );
 
 			// Set-up Action and Filter Hooks
 			register_uninstall_hook( __FILE__, array( __CLASS__, 'delete_plugin_options' ) );
@@ -173,7 +171,7 @@ class Radio_Buttons_for_Taxonomies {
 	 * @since  1.0
 	 */
 	public function launch( $taxonomy ){
-		if( isset( $this->options['taxonomies'] ) && in_array( $taxonomy, (array) $this->options['taxonomies'] ) ) {
+		if( in_array( $taxonomy, (array) $this->get_options( 'taxonomies' ) ) ) {
 			$this->taxonomies[$taxonomy] = new WordPress_Radio_Taxonomy( $taxonomy );
 		}
 	}
@@ -277,7 +275,7 @@ class Radio_Buttons_for_Taxonomies {
 	public function block_editor_assets(){
 		wp_enqueue_script( 'radiotax-gutenberg-sidebar', plugins_url( 'js/dist/index.js', __FILE__ ), array( 'wp-i18n', 'wp-edit-post', 'wp-element', 'wp-editor', 'wp-components', 'wp-data', 'wp-plugins', 'wp-edit-post', 'wp-api' ), self::$version );
 
-		$i18n = array( 'radio_taxonomies' => (array) $this->options['taxonomies'] );
+		$i18n = array( 'radio_taxonomies' => (array) $this->get_options( 'taxonomies' ) );
 		wp_localize_script( 'radiotax-gutenberg-sidebar', 'RB4Tl18n', $i18n );
 	}
 
@@ -389,6 +387,33 @@ class Radio_Buttons_for_Taxonomies {
 	public function is_wp_version_gte( $version = '4.4.0' ) {
 		global $wp_version;
 		return version_compare( $wp_version, $version, '>=' );
+	}
+
+	/**
+	 * Get the plugin options
+	 *
+	 * @since 2.0.3
+	 *
+	 * @param string $option - A specific plugin option to retrieve.
+	 * @param mixed
+	 * @return bool
+	 */
+	public function get_options( $option = false) {
+		if( ! $this->options ) {
+
+			$defaults = array(
+				'taxonomies' => array(),
+				'delete'     => 0,
+			);
+			$this->options = wp_parse_args( get_option( 'radio_button_for_taxonomies_options', true ), $defaults );
+
+		}
+
+		if( $option && isset( $this->options[ $option ] ) ) {
+			return $this->options[ $option ];
+		} else {
+			return $this->options;
+		}
 	}
 
 } // end class

--- a/radio-buttons-for-taxonomies.php
+++ b/radio-buttons-for-taxonomies.php
@@ -351,29 +351,6 @@ class Radio_Buttons_For_Taxonomies {
 	}
 
 	/**
-	 * Make sure Multilingual Press shows the correct user interface.
-	 *
-	 * This method is called after switch_to_blog(), so we have to fetch the
-	 * options separately.
-	 *
-	 * @wp-hook mlp_mutually_exclusive_taxonomies
-	 * @param array $taxonomies
-	 * @return array
-	 */
-	public function multilingualpress_support( Array $taxonomies ) {
-
-		$remote_options = get_option( 'radio_button_for_taxonomies_options', array() );
-
-		if ( empty ( $remote_options['taxonomies'] ) )
-			return $taxonomies;
-
-		$all_taxonomies = array_merge( (array) $remote_options['taxonomies'], $taxonomies );
-
-		return array_unique( $all_taxonomies );
-	}
-
-
-	/**
 	 * Test WordPress current version
 	 *
 	 * @deprecated
@@ -423,6 +400,32 @@ class Radio_Buttons_For_Taxonomies {
 		} else {
 			return $this->options;
 		}
+	}
+
+	// ------------------------------------------------------------------------------
+	// Compatibility
+	// ------------------------------------------------------------------------------
+
+	/**
+	 * Make sure Multilingual Press shows the correct user interface.
+	 *
+	 * This method is called after switch_to_blog(), so we have to fetch the
+	 * options separately.
+	 *
+	 * @wp-hook mlp_mutually_exclusive_taxonomies
+	 * @param array $taxonomies
+	 * @return array
+	 */
+	public function multilingualpress_support( Array $taxonomies ) {
+
+		$remote_options = get_option( 'radio_button_for_taxonomies_options', array() );
+
+		if ( empty( $remote_options['taxonomies'] ) )
+			return $taxonomies;
+
+		$all_taxonomies = array_merge( (array) $remote_options['taxonomies'], $taxonomies );
+
+		return array_unique( $all_taxonomies );
 	}
 
 } // end class

--- a/radio-buttons-for-taxonomies.php
+++ b/radio-buttons-for-taxonomies.php
@@ -18,46 +18,43 @@
  * @license           http://opensource.org/licenses/gpl-3.0.php GNU Public License
  *
  * Props to by Stephen Harris http://profiles.wordpress.org/stephenh1988/
- * For his wp.tuts+ tutorial: http://wp.tutsplus.com/tutorials/creative-coding/how-to-use-radio-buttons-with-taxonomies/ 
+ * For his wp.tuts+ tutorial: http://wp.tutsplus.com/tutorials/creative-coding/how-to-use-radio-buttons-with-taxonomies/
  */
 
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
-
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 if ( class_exists( 'Radio_Buttons_for_Taxonomies' ) ) {
 	return;
 }
 
-class Radio_Buttons_for_Taxonomies {
+/**
+ * Main plugin class.
+ *
+ * @class    Radio_Buttons_for_Taxonomies
+ */
+class Radio_Buttons_For_Taxonomies {
 
 	/**
+	 * Donation URL for USA Women's National Team.
+	 *
 	* @constant string donate url
 	* @since 1.7.8
 	*/
-	CONST DONATE_URL = "https://www.paypal.com/fundraiser/charity/1451316";
+	const DONATE_URL = "https://www.paypal.com/fundraiser/charity/1451316";
 
-	/**
-	 * @var Radio_Buttons_for_Taxonomies The single instance of the class
-	 * @since 1.6.0
-	 */
+	/* @var obj $instance The single instance of Radio_Buttons_for_Taxonomies.*/
 	protected static $_instance = null;
 
-	/**
-	 * @var version
-	 * @since 1.7.0
-	 */
-	static $version = '2.0.2';
+	/* @var str $version */
+	public static $version = '2.0.2';
 
-	/**
-	 * @var plugin options
-	 * @since 1.7.0
-	 */
+	/* @var array $options - The plugin's options.
 	public $options = array();
 
-	/**
-	 * @var taxonomies WordPress_Radio_Taxonomy instances as an array, keyed on taxonomy name.
-	 * @since 1.7.0
-	 */
+	/* @var WordPress_Radio_Taxonomy[] - Array of WordPress_Radio_Taxonomy instances as an array, keyed on taxonomy name. */
 	public $taxonomies = array();
 
 	/**
@@ -83,7 +80,7 @@ class Radio_Buttons_for_Taxonomies {
 	 * @since 1.6.0
 	 */
 	public function __clone() {
-		_doing_it_wrong( __FUNCTION__, __( 'Cloning this object is forbidden.' , 'radio-buttons-for-taxonomies' ), '1.6' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cloning this object is forbidden.', 'radio-buttons-for-taxonomies' ) ), '1.6' );
 	}
 
 	/**
@@ -92,7 +89,7 @@ class Radio_Buttons_for_Taxonomies {
 	 * @since 1.6.0
 	 */
 	public function __wakeup() {
-		_doing_it_wrong( __FUNCTION__, __( 'Unserializing instances of this class is forbidden.' , 'radio-buttons-for-taxonomies' ), '1.6' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Unserializing instances of this class is forbidden.', 'radio-buttons-for-taxonomies' ) ), '1.6' );
 	}
 
 	/**
@@ -103,49 +100,50 @@ class Radio_Buttons_for_Taxonomies {
 	 */
 	public function __construct(){
 
-			// Include required files
-			include_once( 'inc/class.WordPress_Radio_Taxonomy.php' );
+		// Include required files.
+		include_once 'inc/class.WordPress_Radio_Taxonomy.php';
 
-			if( $this->is_wp_version_gte('4.4.0') ){
-				include_once( 'inc/class.Walker_Category_Radio.php' );
-			} else {
-				include_once( 'inc/class.Walker_Category_Radio_old.php' );
-			}
+		if ( $this->is_wp_version_gte('4.4.0') ) {
+			include_once 'inc/class.Walker_Category_Radio.php';
+		} else {
+			include_once 'inc/class.Walker_Category_Radio_old.php';
+		}
 
-			// Set-up Action and Filter Hooks
-			register_uninstall_hook( __FILE__, array( __CLASS__, 'delete_plugin_options' ) );
+		// Set-up Action and Filter Hooks.
+		register_uninstall_hook( __FILE__, array( __CLASS__, 'delete_plugin_options' ) );
 
-			// load plugin text domain for translations
-			add_action( 'init', array( $this, 'load_text_domain' ) );
+		// load plugin text domain for translations.
+		add_action( 'init', array( $this, 'load_text_domain' ) );
 
-			// launch each taxonomy class when tax is registered
-			add_action( 'registered_taxonomy', array( $this, 'launch' ) );
+		// launch each taxonomy class when tax is registered.
+		add_action( 'registered_taxonomy', array( $this, 'launch' ) );
 
-			// register admin settings
-			add_action( 'admin_init', array( $this, 'admin_init' ) );
+		// register admin settings.
+		add_action( 'admin_init', array( $this, 'admin_init' ) );
 
-			// add plugin options page
-			add_action( 'admin_menu', array( $this, 'add_options_page' ) );
+		// add plugin options page.
+		add_action( 'admin_menu', array( $this, 'add_options_page' ) );
 
-			// Load admin scripts
-			add_action( 'admin_enqueue_scripts', array( $this, 'admin_script' ) );
+		// Load admin scripts.
+		add_action( 'admin_enqueue_scripts', array( $this, 'admin_script' ) );
 
-			// Load Gutenberg sidebar scripts
-			add_action( 'enqueue_block_editor_assets', array( $this, 'block_editor_assets' ), 99 );
+		// Load Gutenberg sidebar scripts.
+		add_action( 'enqueue_block_editor_assets', array( $this, 'block_editor_assets' ), 99 );
 
-			// add settings link to plugins page
-			add_filter( 'plugin_action_links_' . plugin_basename(__FILE__), array( $this, 'add_action_links' ), 10, 2 );
+		// Add settings link to plugins page.
+		add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'add_action_links' ), 10, 2 );
 
-			// Add Donate link to plugin.
-			add_filter( 'plugin_row_meta', array( $this, 'add_meta_links' ), 10, 2 );
+		// Add Donate link to plugin.
+		add_filter( 'plugin_row_meta', array( $this, 'add_meta_links' ), 10, 2 );
 
-			// Multilingualpress support.
-			add_filter( 'mlp_mutually_exclusive_taxonomies', array( $this, 'multilingualpress_support' ) );
+		// Multilingualpress support.
+		add_filter( 'mlp_mutually_exclusive_taxonomies', array( $this, 'multilingualpress_support' ) );
 	}
 
 
 	/**
-	 * Delete options table entries ONLY when plugin deactivated AND deleted
+	 * Delete options table entries ONLY when plugin deactivated AND deleted.
+	 *
 	 * @access public
 	 * @return void
 	 * @since  1.0
@@ -155,19 +153,20 @@ class Radio_Buttons_for_Taxonomies {
 		if( isset( $options['delete'] ) && $options['delete'] ) delete_option( 'radio_button_for_taxonomies_options' );
 	}
 
-
 	/**
 	 * Make plugin translation-ready
+	 *
 	 * @access public
 	 * @return void
 	 * @since  1.0
 	 */
 	public function load_text_domain() {
-		load_plugin_textdomain( "radio-buttons-for-taxonomies", false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+		load_plugin_textdomain( 'radio-buttons-for-taxonomies', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 	}
 
 	/**
 	 * For each taxonomy that we are converting to radio buttons, store in taxonomies class property, ex: $this->taxonomies[categories]
+	 *
 	 * @access public
 	 * @return object
 	 * @since  1.0
@@ -184,17 +183,19 @@ class Radio_Buttons_for_Taxonomies {
 
 	/**
 	 * Whitelist plugin options
+	 *
 	 * @access public
 	 * @return void
 	 * @since  1.0
 	 */
 	public function admin_init(){
-		register_setting( 'radio_button_for_taxonomies_options', 'radio_button_for_taxonomies_options', array( $this,'validate_options' ) );
+		register_setting( 'radio_button_for_taxonomies_options', 'radio_button_for_taxonomies_options', array( $this, 'validate_options' ) );
 	}
 
 
 	/**
 	 * Add plugin's options page
+	 *
 	 * @access public
 	 * @return void
 	 * @since  1.0
@@ -205,26 +206,28 @@ class Radio_Buttons_for_Taxonomies {
 
 	/**
 	 * Render the Plugin options form
+	 *
 	 * @access public
 	 * @return void
 	 * @since  1.0
 	 */
-	public function render_form(){
-		include( 'inc/plugin-options.php' );
+	public function render_form() {
+		include 'inc/plugin-options.php';
 	}
 
 	/**
 	 * Sanitize and validate options
+	 *
 	 * @access public
 	 * @param  array $input
 	 * @return array
 	 * @since  1.0
 	 */
-	public function validate_options( $input ){
+	public function validate_options( $input ) {
 
 		$clean = array();
 
-		//probably overkill, but make sure that the taxonomy actually exists and is one we're cool with modifying
+		// Probably overkill, but make sure that the taxonomy actually exists and is one we're cool with modifying.
 		$taxonomies = $this->get_all_taxonomies();
 
 		if( isset( $input['taxonomies'] ) ) {
@@ -235,13 +238,14 @@ class Radio_Buttons_for_Taxonomies {
 			}
 		}
 
-		$clean['delete'] =  isset( $input['delete'] ) && $input['delete'] ? 1 : 0 ;  //checkbox
+		$clean['delete'] =  isset( $input['delete'] ) && $input['delete'] ? 1 : 0 ;  // Checkbox.
 
 		return $clean;
 	}
 
 	/**
 	 * Enqueue Scripts
+	 *
 	 * @access public
 	 * @return void
 	 * @since  1.0
@@ -270,12 +274,13 @@ class Radio_Buttons_for_Taxonomies {
 
 	/**
 	 * Load Gutenberg Sidebar Scripts
+	 *
 	 * @access public
 	 * @return void
 	 * @since  2.0
 	 */
 	public function block_editor_assets(){
-		wp_enqueue_script( 'radiotax-gutenberg-sidebar', plugins_url( 'js/dist/index.js', __FILE__ ), array( 'wp-i18n', 'wp-edit-post', 'wp-element', 'wp-editor', 'wp-components', 'wp-data', 'wp-plugins', 'wp-edit-post', 'wp-api' ), self::$version );
+		wp_enqueue_script( 'radiotax-gutenberg-sidebar', plugins_url( 'js/dist/index.js', __FILE__ ), array( 'wp-i18n', 'wp-edit-post', 'wp-element', 'wp-editor', 'wp-components', 'wp-data', 'wp-plugins', 'wp-edit-post', 'wp-api' ), self::$version, true );
 
 		$i18n = array( 'radio_taxonomies' => (array) $this->get_options( 'taxonomies' ) );
 		wp_localize_script( 'radiotax-gutenberg-sidebar', 'RB4Tl18n', $i18n );
@@ -283,6 +288,7 @@ class Radio_Buttons_for_Taxonomies {
 
 	/**
 	 * Display a Settings link on the main Plugins page
+	 *
 	 * @access public
 	 * @param  array $links
 	 * @param  string $file
@@ -291,20 +297,21 @@ class Radio_Buttons_for_Taxonomies {
 	 */
 	public function add_action_links( $links, $file ) {
 
-		$plugin_link = '<a href="'.admin_url( 'options-general.php?page=radio-buttons-for-taxonomies' ) . '">' . __( 'Settings' , 'radio-buttons-for-taxonomies' ) . '</a>';
+		$plugin_link = '<a href="' . admin_url( 'options-general.php?page=radio-buttons-for-taxonomies' ) . '">' . esc_html_e( 'Settings', 'radio-buttons-for-taxonomies' ) . '</a>';
 		// make the 'Settings' link appear first
 		array_unshift( $links, $plugin_link );
-		
+
 		return $links;
 	}
 
 
 	/**
-	* Add donation link
-	* @param array $plugin_meta
-	* @param string $plugin_file
-	* @since 1.7.8
-	*/
+	 * Add donation link
+	 *
+	 * @param array $plugin_meta - The  plugin's meta data.
+	 * @param string $plugin_file - This base file.
+	 * @since 1.7.8
+	 */
 	public function add_meta_links( $plugin_meta, $plugin_file ) {
 		if( $plugin_file == plugin_basename(__FILE__) ){
 			$plugin_meta[] = '<a class="dashicons-before dashicons-awards" href="' . self::DONATE_URL . '" target="_blank">' . __( 'Donate', 'radio-buttons-for-taxonomies' ) . '</a>';

--- a/radio-buttons-for-taxonomies.php
+++ b/radio-buttons-for-taxonomies.php
@@ -24,7 +24,9 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 
-if ( ! class_exists( 'Radio_Buttons_for_Taxonomies' ) ) :
+if ( class_exists( 'Radio_Buttons_for_Taxonomies' ) ) {
+	return;
+}
 
 class Radio_Buttons_for_Taxonomies {
 

--- a/radio-buttons-for-taxonomies.php
+++ b/radio-buttons-for-taxonomies.php
@@ -7,7 +7,7 @@
  * Author:            helgatheviking
  * Author URI:        https://www.kathyisawesome.com
  * Requires at least: 4.5.0
- * Tested up to:      5.1.1
+ * Tested up to:      5.2.4
  *
  * Text Domain:       radio-buttons-for-taxonomies
  * Domain Path:       /languages/

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 **Tags:** taxonomy, admin, interface, ui, post, radio, terms, metabox  
 **Requires at least:** 4.5.0  
 **Tested up to:** 5.1.1  
-**Stable tag:** 2.0.2  
+**Stable tag:** 2.0.3  
 **License:** GPLv3 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-3.0.html  
 
@@ -52,6 +52,9 @@ So for example, to disabled the "No term" option on a taxonomy called "genre" yo
 
 
 ## Changelog ##
+
+### 2.0.3 ###
+* Fix: Stop breaking quick edit on Taxonomy pages.
 
 ### 2.0.2 ###
 * Update from [Gutenberg source](https://github.com/WordPress/gutenberg/pull/14786)

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/fundraiser/charity/1451316
 Tags: taxonomy, admin, interface, ui, post, radio, terms, metabox
 Requires at least: 4.5.0
 Tested up to: 5.1.1
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -52,6 +52,9 @@ add_filter( 'radio_buttons_for_taxonomies_no_term_genre', '__return_FALSE' );
 `
 
 == Changelog ==
+
+= 2.0.3 =
+* Fix: Stop breaking quick edit on Taxonomy pages.
 
 = 2.0.2 =
 * Update from [Gutenberg source](https://github.com/WordPress/gutenberg/pull/14786)


### PR DESCRIPTION
Use conditional logic to determine when the script is loaded. 