### PR TITLE
Optimize launch of radio instances and remove unnecessary repeats in …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 build/
 package-lock.json
 *.afdesign
+*.idea
+*.DS_Store

--- a/radio-buttons-for-taxonomies.php
+++ b/radio-buttons-for-taxonomies.php
@@ -112,8 +112,9 @@ class Radio_Buttons_For_Taxonomies {
 		// load plugin text domain for translations.
 		add_action( 'init', array( $this, 'load_text_domain' ) );
 
-		// launch each taxonomy class when tax is registered.
-		add_action( 'registered_taxonomy', array( $this, 'launch' ) );
+		// launch each taxonomy class
+		// Other hook than 'registered_taxonomy', one that only runs once, priority is needed
+		add_action( 'init', array( $this, 'launch' ), 99);
 
 		// register admin settings.
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
@@ -171,9 +172,14 @@ class Radio_Buttons_For_Taxonomies {
 	 * @return object
 	 * @since  1.0
 	 */
-	public function launch( $taxonomy ) {
-		if ( $this->is_radio_tax( $taxonomy ) ) {
-			$this->taxonomies[$taxonomy] = new WordPress_Radio_Taxonomy( $taxonomy );
+	public function launch() {
+		// Run only for taxonomies we need, instead of running for all custom taxonomies and checkin if it is a radio tax
+		// Also this function now runs only once instead of on every taxnomomy registration
+		$radiotaxonomies = $this->get_options( 'taxonomies' );
+
+		// Loop through selected posttypes
+		foreach ($radiotaxonomies as $radiotaxonomy ) {
+			$this->taxonomies[$radiotaxonomy] = new WordPress_Radio_Taxonomy( $radiotaxonomy  );
 		}
 	}
 


### PR DESCRIPTION
Hi Kathy, 

I managed to optimise the plugin by removing a lot of unnecessary repeating functions in several places:

1. radio-buttons-for-taxonomies.php

-line 117: launch() was called on the hook 'registered_taxonomy', which runs after every registered taxonomy (a lot in my case). It only needs to run once for every radio taxonomy in the settings.
I hooked it into init with a late priority, this works, could be another hook maybe.

-line 175: launch() function
Instead of running through all registered taxonomies, run only once and loop through the ones checked in options.

2. inc/class.WordPress_Radio_Taxonomy

-line 47: hook the remove_meta_box function into 'current_screen' instead of 'admin_menu'. Because we need get_current_screen() further on, which is not available yet in 'admin_menu' hook.

-line 77: remove_meta_box() function.
This was running many times depending on the amount of radio taxonomies and amount of post-types connected to them. In my case sometimes 20x when only one time is needed.
In the function you were iterating over the post types in the taxonomy object. This is unnecessary: we only need to check if we are on one of these posttypes and then run the function.
So I removed the foreach, get the posttype of the current screen, and run a check if this is in the array of posttypes in the taxonomy object. If so, then add the metabox to the current screen.

-line 108: same for add_meta_box().

I tested this on single post edit screens, post list screens with Quick Edit and Bulk Edit. Seems to work fine for all. 

I hope I am not overlooking something.