### PR TITLE
Revert input names from radio_tax_input to core tax_input. Closes #71. [WIP]

### DIFF
--- a/inc/class-walker-category-radio-old.php
+++ b/inc/class-walker-category-radio-old.php
@@ -66,8 +66,6 @@ class Walker_Category_Radio extends Walker {
 		if ( empty($taxonomy) )
 			$taxonomy = 'category';
 
-		$name = 'radio_tax_input['.$taxonomy.']';
-
 		//get first term object
 		$current_term = ! empty( $selected_cats ) && ! is_wp_error( $selected_cats ) ? array_pop( $selected_cats ) : false;
 

--- a/inc/class-walker-category-radio.php
+++ b/inc/class-walker-category-radio.php
@@ -75,10 +75,6 @@ class Walker_Category_Radio extends Walker {
 			$this->printed_nonce = true;
 		}
 
-		/* RB4T mod: Replace default $name variable */
-		$name = 'radio_tax_input['.$taxonomy.']';
-		/* end */
-
 		$args['popular_cats'] = empty( $args['popular_cats'] ) ? array() : $args['popular_cats'];
 		$class = in_array( $category->term_id, $args['popular_cats'] ) ? ' class="popular-category"' : '';
 

--- a/inc/class-wordpress-radio-taxonomy.php
+++ b/inc/class-wordpress-radio-taxonomy.php
@@ -395,7 +395,7 @@ class WordPress_Radio_Taxonomy {
 				$cat_id = $cat_id['term_id'];
 			}
 
-			$data = sprintf( '<li id="%1$s-%2$s"><label class="selectit"><input id="in-%1$s-%2$s" type="radio" name="radio_tax_input[%1$s][]" value="%2$s" checked="checked"> %3$s</label></li>',
+			$data = sprintf( '<li id="%1$s-%2$s"><label class="selectit"><input id="in-%1$s-%2$s" type="radio" name="tax_input[%1$s][]" value="%2$s" checked="checked"> %3$s</label></li>',
 				esc_attr( $taxonomy->name ),
 				intval( $cat_id ),
 				esc_html( $cat_name )
@@ -443,9 +443,9 @@ class WordPress_Radio_Taxonomy {
 		}
 
 		// OK, we must be authenticated by now: we need to find and save the data.
-		if ( isset( $_REQUEST["radio_tax_input"]["{$this->taxonomy}"] ) ) {
+		if ( isset( $_REQUEST["tax_input"]["{$this->taxonomy}"] ) ) {
 
-			$terms = (array) $_REQUEST["radio_tax_input"]["{$this->taxonomy}"]; 
+			$terms = (array) $_REQUEST["tax_input"]["{$this->taxonomy}"]; 
 
 			// If category and not saving any terms, set to default.
 			if ( 'category' == $this->taxonomy && empty ( $terms ) ) {


### PR DESCRIPTION
change input names back to core. This actually allows WP core to handle the save routine, so the [`save_single_term()`](https://github.com/helgatheviking/Radio-Buttons-for-Taxonomies/blob/e8f5ac9f80990743519d226432351cc43f3e5b74/inc/class-wordpress-radio-taxonomy.php#L426) method may not be needed. It appears to save, question will be if we really need to double-check this _and_ if the previous term is removed. 