### PR TITLE
Fix missing translations in block editor

### DIFF
--- a/radio-buttons-for-taxonomies.php
+++ b/radio-buttons-for-taxonomies.php
@@ -299,6 +299,8 @@ class Radio_Buttons_For_Taxonomies {
 			true
 		);
 
+		wp_set_script_translations( 'radiotax-gutenberg-sidebar', 'radio-buttons-for-taxonomies' );
+
 		$i18n = array( 'radio_taxonomies' => (array) $this->get_options( 'taxonomies' ) );
 		wp_localize_script( 'radiotax-gutenberg-sidebar', 'RB4Tl18n', $i18n );
 	}


### PR DESCRIPTION
Adds the required `wp_set_script_translations()` call to ensure translations are loaded.

| Before | After |
| -- | -- |
| <img width="196" alt="Bildschirmfoto 2021-12-22 um 09 19 13" src="https://user-images.githubusercontent.com/617637/147063517-9346c3c4-333a-4c04-a22d-2aeed80ebbe0.png"> | <img width="226" alt="Bildschirmfoto 2021-12-22 um 09 45 46" src="https://user-images.githubusercontent.com/617637/147063546-556d9d5a-77b5-4ef3-becd-b714775d221b.png"> |
 