### PR TITLE
Fix bulk edit removing terms

### DIFF
--- a/inc/class-wordpress-radio-taxonomy.php
+++ b/inc/class-wordpress-radio-taxonomy.php
@@ -430,6 +430,11 @@ class WordPress_Radio_Taxonomy {
 	 */
 	function save_single_term( $post_id ) {
 
+		// If posts are being bulk edited, we don't want to do anything.
+		if ( ! empty( $_GET['bulk_edit'] ) ) {
+			return $post_id;
+		}
+
 		// Verify if this is an auto save routine. If it is our form has not been submitted, so we dont want to do anything.
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return $post_id;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prevents terms from being removed when performing a bulk edit in the admin

#### Testing instructions

1. Select multiple posts in the post list screen
2. In the Bulk Actions select box choose Edit
3. Change something like the author or status
4. Click Submit
5. Confirm that terms are no longer being removed

Fixes #105 